### PR TITLE
Fix infinite choices on a proposal

### DIFF
--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -141,6 +141,7 @@ export default {
         this.form.end &&
         this.form.end > this.form.start &&
         this.choices.length >= 2 &&
+        this.choices.length <= 30 &&
         !this.choices.some(a => a.text === '')
       );
     },


### PR DESCRIPTION
Anyone can add an unlimited number of choices on a proposal. I think there is no reason for that, and it could possible be a vulnerability. I added a check that the choices aren't more than 30.